### PR TITLE
write to /run instead of /home

### DIFF
--- a/doc/singleinstance.dox
+++ b/doc/singleinstance.dox
@@ -20,7 +20,7 @@ Exec=/usr/bin/invoker --single-instance --type=e /usr/bin/myApp
 \endverbatim
 
 As a result, a lock file 
-\c $HOME/.single-instance-locks/usr/bin/myApp/instance.lock is created. 
+\c $XDG_RUNTIME_DIR/single-instance-locks/usr/bin/myApp/instance.lock is created. 
 If applauncherd cannot acquire the lock, it tries to find the corresponding
 window and activates it. 
 

--- a/src/launcherlib/daemon.cpp
+++ b/src/launcherlib/daemon.cpp
@@ -52,7 +52,7 @@ Daemon * Daemon::m_instance = NULL;
 int Daemon::m_lockFd = -1;
 const int Daemon::m_boosterSleepTime = 2;
 
-const std::string Daemon::m_stateDir = std::string(getenv("HOME"))+"/.applauncherd";
+const std::string Daemon::m_stateDir = std::string(getenv("XDG_RUNTIME_DIR"))+"/applauncherd";
 const std::string Daemon::m_stateFile = Daemon::m_stateDir + "/saved-state";
 
 Daemon::Daemon(int & argc, char * argv[]) :
@@ -117,7 +117,7 @@ bool Daemon::lock()
     fl.l_len = 1;
 
     std::stringstream lock_file;
-    lock_file << getenv("HOME") << "/applauncherd.lock";
+    lock_file << getenv("XDG_RUNTIME_DIR") << "/applauncherd.lock";
   
     if((m_lockFd = open(lock_file.str().c_str(), O_WRONLY | O_CREAT, 0666)) == -1)
         return false;

--- a/src/single-instance/main.cpp
+++ b/src/single-instance/main.cpp
@@ -40,7 +40,7 @@ extern "C" {
 namespace
 {
     int g_lockFd = -1;
-    const std::string LOCK_PATH_BASE(std::string(getenv("HOME"))+"/.single-instance-locks/");
+    const std::string LOCK_PATH_BASE(std::string(getenv("XDG_RUNTIME_DIR"))+"/single-instance-locks/");
     const std::string LOCK_FILE_NAME("instance.lock");
 }
 
@@ -264,7 +264,7 @@ extern "C"
      * \brief Try to acquire a lock file.
      *
      * Tries to acquire a lock currently at
-     * $HOME/.single-instance-locks/[binaryName]/instance.lock
+     * $XDG_RUNTIME_DIR/single-instance-locks/[binaryName]/instance.lock
      *
      * \param binaryName Full path to the binary.
      * \return true if succeeded, false on failure.

--- a/tests/meego/testscripts/utils.py
+++ b/tests/meego/testscripts/utils.py
@@ -28,7 +28,7 @@ def remove_applauncherd_runtime_files():
     Removes files that applauncherd leaves behind after it has been stopped
     """
 
-    files = ["%s/applauncherd.lock" % (os.environ['HOME'])]
+    files = ["%s/applauncherd.lock" % (os.environ['XDG_RUNTIME_DIR'])]
     files += glob.glob('/tmp/boost*')
 
     for f in files:


### PR DESCRIPTION
XDG_RUNTIME_DIR is tmpfs where HOME is just normal filesystem. We can avoid
some write operations to emmc when we do move these to tmpfs. Also
these files are something that should be reset on each boot anyway.

Signed-off-by: Marko Saukko marko.saukko@jollamobile.com
