### PR TITLE
[booster] Remove unused / broken code

### DIFF
--- a/src/launcherlib/booster.h
+++ b/src/launcherlib/booster.h
@@ -213,10 +213,6 @@ private:
     //! True, if being run in boot mode.
     bool m_bootMode;
 
-    //! Group ID to flip to and back to generate an event for policy
-    //! (re)classification.
-    gid_t m_boosted_gid;
-
 #ifdef UNIT_TEST
     friend class Ut_Booster;
 #endif


### PR DESCRIPTION
We don't have a "boosted" group anymore, so the call fails.
Remove all code related to the failing call.

The re-classification for policy does not seem to be needed anymore?
And if it is indeed still needed, it probably doesn't work atm.
