### PR TITLE
[launcherlib] Handle failures of resolving main() dynamically

### DIFF
--- a/src/launcherlib/booster.cpp
+++ b/src/launcherlib/booster.cpp
@@ -262,7 +262,14 @@ int Booster::run(SocketManager * socketManager)
 
         // Execute the binary
         Logger::logDebug("Booster: invoking '%s' ", m_appData->fileName().c_str());
-        return launchProcess();
+        try {
+            return launchProcess();
+        } catch (const std::runtime_error &e) {
+            Logger::logError("Booster: Failed to invoke: %s\n", e.what());
+            // Also log to the terminal so the error appears on the terminal too
+            fprintf(stderr, "Failed to invoke: %s\n", e.what());
+            return EXIT_FAILURE;
+        }
     }
     else
     {


### PR DESCRIPTION
In case where the binary to be invoked is either not a shared library
object (e.g. it's a shell script) or when main() cannot be resolved
as shared library (because it hasn't been exported as such), instead
of abort()ing due to an uncaught exception, handle the exception and
print the error message in the log + on the console, and then fail.
