### PR TITLE
Allow booster start earlier during the startup.

### DIFF
--- a/rpm/mapplauncherd.spec
+++ b/rpm/mapplauncherd.spec
@@ -54,7 +54,7 @@ rm -rf %{buildroot}
 # Don't use %exclude, remove at install phase
 rm -f %{buildroot}/usr/share/fala_images/fala_qml_helloworld
 
-mkdir -p %{buildroot}/usr/lib/systemd/user/user-session.target.wants || true
+mkdir -p %{buildroot}/usr/lib/systemd/user/user-session.target.wants
 ln -s ../booster-generic.service %{buildroot}/usr/lib/systemd/user/user-session.target.wants/
 
 %pre

--- a/src/booster-generic/booster-generic.service
+++ b/src/booster-generic/booster-generic.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Generic application launch booster
-After=pre-user-session.target
-Requires=dbus.socket pre-user-session.target
+After=dbus.socket
+Requires=dbus.socket
 
 [Service]
 Type=notify


### PR DESCRIPTION
[systemd] Allow booster to start earlier in the bootup.
[packaging] Drop .yaml support.

Signed-off-by: Marko Saukko <marko.saukko@jolla.com>