### PR TITLE
[invoker] Reduce the default respawn delay. Contributes to JB#30107

### DIFF
--- a/src/invoker/invoker.c
+++ b/src/invoker/invoker.c
@@ -52,7 +52,7 @@ static const unsigned int MAX_EXIT_DELAY = 86400;
 
 // Delay before a new booster is started. This will
 // be sent to the launcher daemon.
-static const unsigned int RESPAWN_DELAY     = 3;
+static const unsigned int RESPAWN_DELAY     = 1;
 static const unsigned int MIN_RESPAWN_DELAY = 0;
 static const unsigned int MAX_RESPAWN_DELAY = 10;
 


### PR DESCRIPTION
This was perhaps a reasonable default 5 years ago, but today 1s is plenty.